### PR TITLE
Fixed compilation error

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -11,7 +11,6 @@
 // Graphics
 #include "deck_gfx.h"
 #include "background_gfx.h"
-#include "background_play_gfx.h"
 #include "affine_background_gfx.h"
 
 // Audio


### PR DESCRIPTION
It seems the removal of background_play_gfx.h was missed.
I suppose this error was missed because the old compiled header was still there but if you do make clean, then make, you will see it.