### PR TITLE
Fixed blind bottom of rect overwrite on skip bug

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -548,7 +548,7 @@ void change_background(int id)
                 }
 
                 // Copy plain tiles onto the bottom of the raised blind panel to fill the gap created by the raise
-                Rect gap_fill_rect = {x_from, y_from, x_from + 5, y_from};
+                Rect gap_fill_rect = {x_from, y_from, x_from + rect_width(&SINGLE_BLIND_SELECT_RECT) - 1, y_from}; // - 1 to stay within rect boundaries
                 BG_POINT gap_fill_point = {x_to, y_to};
                 main_bg_se_copy_rect(gap_fill_rect, gap_fill_point);
 


### PR DESCRIPTION
This is a fix for a bug that occurs when the small blind is skipped where the bottom left corner of the boss blind rect is overwritten.

<img width="240" height="160" alt="blind_skip_rect_overwrite_bug" src="https://github.com/user-attachments/assets/6a9f6c10-5e6a-401c-ac7c-a54f4df55b94" />
