### PR TITLE
Fix for blind requirement overflow on 4 digits

### DIFF
--- a/include/graphic_utils.h
+++ b/include/graphic_utils.h
@@ -36,6 +36,9 @@
 #define SE_UP	-1
 #define SE_DOWN 1
 
+#define OVERFLOW_LEFT	-1
+#define OVERFLOW_RIGHT	1
+
 // Tile size in pixels, both height and width as tiles are square
 #define TILE_SIZE 8
 
@@ -100,5 +103,19 @@ void main_bg_se_move_rect_1_tile_vert(Rect se_rect, int direction);
 
 // A wrapper for tte_erase_rect that would use the rect struct
 void tte_erase_rect_wrapper(Rect rect);
+
+/* Changes rect->left so it fits the digits of num exactly when right aligned to rect->right.
+ * Assumes num is not negative.
+ * 
+ * overflow_direction determines the direction the number will overflow
+ * if it's too large to fit inside the rect. 
+ * Should be either OVERFLOW_LEFT or OVERFLOW_RIGHT.
+ * 
+ * The rect is in number of pixels but should be a multiple of TILE_SIZE
+ * so it's a whole number of tiles to fit TTE characters
+ * 
+ * Note that both rect->left and rect-right need to be defined, top and bottom don't matter
+ */
+void update_text_rect_to_right_align_num(Rect* rect, int num, int overflow_direction);
 
 #endif //GRAPHIC_UTILS_H

--- a/source/graphic_utils.c
+++ b/source/graphic_utils.c
@@ -2,6 +2,7 @@
 #include <tonc_tte.h>
 #include <tonc_math.h>
 
+#include "util.h"
 #include "graphic_utils.h"
 
 const Rect FULL_SCREENBLOCK_RECT = { 0, 0, SE_ROW_LEN, SE_COL_LEN };
@@ -143,5 +144,21 @@ void main_bg_se_copy_tile_to_rect(u16 tile, Rect se_rect)
 void tte_erase_rect_wrapper(Rect rect)
 {
     tte_erase_rect(rect.left, rect.top, rect.right, rect.bottom);
+}
+
+void update_text_rect_to_right_align_num(Rect* rect, int num, int overflow_direction)
+{
+    int num_digits = get_digits(num);
+    if (overflow_direction == OVERFLOW_RIGHT)
+    {
+        rect->left = max(0, rect->right - num_digits * TILE_SIZE);
+    }
+    else if (overflow_direction == OVERFLOW_LEFT)
+    {
+        int num_fitting_digits = rect_width(rect) / TILE_SIZE;
+        if (num_digits < num_fitting_digits)
+            rect->left += (num_fitting_digits - num_digits) * TILE_SIZE;
+        //else nothing is to be updated, entire rect is filled and may overflow
+    }
 }
 


### PR DESCRIPTION
I fixed the blind requirement overflow on 4 digits and added a function to update a text rect to right-align a number for that. I figured the blind requirement is meant to be right-aligned though it might meant to be center-aligned, I suppose it doesn't matter since it's always 3 or 4 characters.
This will still overflow for more than 4 digits, I suppose when we use "K" to abbreviate thousands we will need to update it to right align by a string and not a number, I just didn't want to go into it right now.