### PR TITLE
Added flag to Makefile to treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GRAPHICS	:= graphics
 #---------------------------------------------------------------------------------
 ARCH	:=	-mthumb -mthumb-interwork
 
-CFLAGS	:= -O3 -Wall \
+CFLAGS	:= -O3 -Wall -Werror\
         -mcpu=arm7tdmi -mtune=arm7tdmi \
         -ffast-math -fomit-frame-pointer -funroll-loops \
         $(ARCH)

--- a/source/game.c
+++ b/source/game.c
@@ -2030,7 +2030,9 @@ void game_round_end()
         case 6: // This state handles displaying the rewards earned from the completed round
         {
             int hand_y = 0;
-            int interest_y = 0;
+
+            // TODO: Implement interest
+            //int interest_y = 0;
 
             if (hands > 0)
             {


### PR DESCRIPTION
I added the -Werror flag to the Makefile so it treats warnings as error and fails the build when there are warnings.
I also commented out the interest code in game.c that generated warnings to be warning free.
I think it's better to strive for warning free code, and this makes sure no warnings are introduced.