### PR TITLE
(Needs Art) Refactor jokers to use struct and function pointer for joker effects

### DIFF
--- a/include/joker.h
+++ b/include/joker.h
@@ -25,7 +25,6 @@
 #define RARE_JOKER 2
 #define LEGENDARY_JOKER 3
 
-#define MAX_JOKERS 2 // The current maximum jokers added
 #define MAX_JOKER_OBJECTS 32 // The maximum number of joker objects that can be created at once
 
 #define DEFAULT_JOKER_ID 0
@@ -54,6 +53,15 @@ typedef struct  // These jokers are triggered after the played hand has finished
     int money;
     bool retrigger; // Retrigger played hand (e.g. "Dusk" joker, even though on the wiki it says "On Scored" it makes more sense to have it here)
 } JokerEffect;
+
+typedef JokerEffect (*JokerEffectFunc)(Joker *joker, Card *scored_card);
+typedef struct {
+    u8 rarity;
+    u8 base_value;
+    JokerEffectFunc effect;
+} JokerInfo;
+extern const JokerInfo joker_registry[];
+extern const size_t joker_registry_size;
 
 void joker_init();
 

--- a/include/joker.h
+++ b/include/joker.h
@@ -60,8 +60,8 @@ typedef struct {
     u8 base_value;
     JokerEffectFunc effect;
 } JokerInfo;
-extern const JokerInfo joker_registry[];
-extern const size_t joker_registry_size;
+const JokerInfo* get_joker_registry_entry(int joker_id);
+size_t get_joker_registry_size(void);
 
 void joker_init();
 

--- a/include/util.h
+++ b/include/util.h
@@ -35,4 +35,6 @@ static inline int get_digits_even(int n)
 
 #define UNDEFINED -1
 
+#define NUM_ELEM_IN_ARR(arr) (sizeof(arr) / sizeof((arr)[0]))
+
 #endif // UTIL_H

--- a/source/game.c
+++ b/source/game.c
@@ -1825,7 +1825,7 @@ static void game_shop_create_items(JokerObject *shop_jokers[], bool first_time)
             joker_object_destroy(&shop_jokers[i]); // Destroy the joker object if it exists
         }
         
-        u8 joker_id = random() % MAX_JOKERS;
+        u8 joker_id = random() % joker_registry_size;
 
         shop_jokers[i] = joker_object_new(joker_new(joker_id));
         shop_jokers[i]->sprite_object->x = int2fx(120 + i * 32);

--- a/source/game.c
+++ b/source/game.c
@@ -1825,7 +1825,7 @@ static void game_shop_create_items(JokerObject *shop_jokers[], bool first_time)
             joker_object_destroy(&shop_jokers[i]); // Destroy the joker object if it exists
         }
         
-        u8 joker_id = random() % joker_registry_size;
+        u8 joker_id = random() % get_joker_registry_size();
 
         shop_jokers[i] = joker_object_new(joker_new(joker_id));
         shop_jokers[i]->sprite_object->x = int2fx(120 + i * 32);

--- a/source/joker.c
+++ b/source/joker.c
@@ -38,10 +38,10 @@ void joker_init()
 
 Joker *joker_new(u8 id)
 {
-    if (id >= joker_registry_size) return NULL;
+    if (id >= get_joker_registry_size()) return NULL;
 
     Joker *joker = malloc(sizeof(Joker));
-    const JokerInfo *jinfo = &joker_registry[id];
+    const JokerInfo *jinfo = get_joker_registry_entry(id);
 
     joker->id = id;
     joker->modifier = BASE_EDITION; // TODO: Make this random later
@@ -61,8 +61,10 @@ void joker_destroy(Joker **joker)
 
 JokerEffect joker_get_score_effect(Joker *joker, Card *scored_card)
 {
-    if (joker->id >= joker_registry_size) return (JokerEffect){0};
-    return joker_registry[joker->id].effect(joker, scored_card);
+    const JokerInfo *jinfo = get_joker_registry_entry(joker->id);
+    if (!jinfo) return (JokerEffect){0};
+
+    return jinfo->effect(joker, scored_card);
 }
 
 // JokerObject methods

--- a/source/joker.c
+++ b/source/joker.c
@@ -12,13 +12,6 @@
 
 #define JOKER_SCORE_TEXT_Y 48
 
-const static u8 joker_data_lut[MAX_JOKERS][2] = // Rarity, Value
-{
-    // TODO: Change to struct
-    {COMMON_JOKER, 2}, // Default Joker
-    {COMMON_JOKER, 5}, // Greedy Joker
-};
-
 const static u8 edition_price_lut[MAX_EDITIONS] =
 {
     0, // BASE_EDITION
@@ -45,12 +38,15 @@ void joker_init()
 
 Joker *joker_new(u8 id)
 {
-    Joker *joker = malloc(sizeof(Joker));
+    if (id >= joker_registry_size) return NULL;
 
-    joker->id = id; // TODO: Make this random later
+    Joker *joker = malloc(sizeof(Joker));
+    const JokerInfo *jinfo = &joker_registry[id];
+
+    joker->id = id;
     joker->modifier = BASE_EDITION; // TODO: Make this random later
-    joker->value = joker_data_lut[id][1] + edition_price_lut[joker->modifier]; // Base value + edition price
-    joker->rarity = joker_data_lut[id][0];
+    joker->value = jinfo->base_value + edition_price_lut[joker->modifier]; // Base value + edition price
+    joker->rarity = jinfo->rarity;
     joker->processed = false;
 
     return joker;
@@ -65,25 +61,8 @@ void joker_destroy(Joker **joker)
 
 JokerEffect joker_get_score_effect(Joker *joker, Card *scored_card)
 {
-    JokerEffect effect = {0};
-
-    switch (joker->id)
-    {
-        case DEFAULT_JOKER_ID: // Default Joker
-            if (scored_card != NULL) break; // Joker is independent, no effect
-            effect.mult = 4;
-            break;
-        case GREEDY_JOKER_ID: // Greedy Joker
-            if (scored_card != NULL && scored_card->suit == DIAMONDS) // If the scored card is a diamond
-            {
-                effect.mult = 3;
-            }
-            break;
-        default:
-            break;
-    }
-
-    return effect;
+    if (joker->id >= joker_registry_size) return (JokerEffect){0};
+    return joker_registry[joker->id].effect(joker, scored_card);
 }
 
 // JokerObject methods

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1,37 +1,33 @@
 #include "joker.h"
 
+
 static JokerEffect default_joker_effect(Joker *joker, Card *scored_card) {
     JokerEffect effect = {0};
     if (scored_card == NULL) effect.mult = 4;
     return effect;
 }
 
-static JokerEffect greedy_joker_effect(Joker *joker, Card *scored_card) {
+static JokerEffect sinful_joker_effect(Card *scored_card, u8 sinful_suit) {
     JokerEffect effect = {0};
-    if (scored_card != NULL && scored_card->suit == DIAMONDS)
+    if (scored_card != NULL && scored_card->suit == sinful_suit)
         effect.mult = 3;
     return effect;
+}
+
+static JokerEffect greedy_joker_effect(Joker *joker, Card *scored_card) {
+    return sinful_joker_effect(scored_card, DIAMONDS);
 }
 
 static JokerEffect lusty_joker_effect(Joker *joker, Card *scored_card) {
-    JokerEffect effect = {0};
-    if (scored_card != NULL && scored_card->suit == HEARTS)
-        effect.mult = 3;
-    return effect;
+    return sinful_joker_effect(scored_card, HEARTS);
 }
 
 static JokerEffect wrathful_joker_effect(Joker *joker, Card *scored_card) {
-    JokerEffect effect = {0};
-    if (scored_card != NULL && scored_card->suit == SPADES)
-        effect.mult = 3;
-    return effect;
+    return sinful_joker_effect(scored_card, SPADES);
 }
 
 static JokerEffect gluttonous_joker_effect(Joker *joker, Card *scored_card) {
-    JokerEffect effect = {0};
-    if (scored_card != NULL && scored_card->suit == CLUBS)
-        effect.mult = 3;
-    return effect;
+    return sinful_joker_effect(scored_card, CLUBS);
 }
 
 const JokerInfo joker_registry[] = {

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1,4 +1,5 @@
 #include "joker.h"
+#include "util.h"
 
 
 static JokerEffect default_joker_effect(Joker *joker, Card *scored_card) {
@@ -38,4 +39,15 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 5, gluttonous_joker_effect },
 };
 
-const size_t joker_registry_size = sizeof(joker_registry) / sizeof(joker_registry[0]);
+static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);
+
+const JokerInfo* get_joker_registry_entry(int joker_id) {
+    if (joker_id < 0 || (size_t)joker_id >= joker_registry_size) {
+        return NULL;
+    }
+    return &joker_registry[joker_id];
+}
+
+size_t get_joker_registry_size(void) {
+    return joker_registry_size;
+}

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1,0 +1,45 @@
+#include "joker.h"
+
+static JokerEffect default_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL) effect.mult = 4;
+    return effect;
+}
+
+static JokerEffect greedy_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL && scored_card->suit == DIAMONDS)
+        effect.mult = 3;
+    return effect;
+}
+
+static JokerEffect lusty_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL && scored_card->suit == HEARTS)
+        effect.mult = 3;
+    return effect;
+}
+
+static JokerEffect wrathful_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL && scored_card->suit == SPADES)
+        effect.mult = 3;
+    return effect;
+}
+
+static JokerEffect gluttonous_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL && scored_card->suit == CLUBS)
+        effect.mult = 3;
+    return effect;
+}
+
+const JokerInfo joker_registry[] = {
+    { COMMON_JOKER, 2, default_joker_effect },  // DEFAULT_JOKER_ID = 0
+    { COMMON_JOKER, 5, greedy_joker_effect },   // GREEDY_JOKER_ID = 1
+    { COMMON_JOKER, 5, lusty_joker_effect },    // etc...
+    { COMMON_JOKER, 5, wrathful_joker_effect },
+    { COMMON_JOKER, 5, gluttonous_joker_effect },
+};
+
+const size_t joker_registry_size = sizeof(joker_registry) / sizeof(joker_registry[0]);


### PR DESCRIPTION
Hi, saw this project on reddit, love it! I wanted to suggest some changes but these are not complete, so I'm marking it as a draft. This adds the lusty, wrathful, and gluttonous jokers. And also refactors joker effects from a switch statement to separate functions.

Some problems before I think this is acceptable to merge:

It needs added artwork for those 3 new jokers, and I'm no artist, not even pixel art haha.

The change is based on the existing `joker_get_score_effect(Joker *joker, Card *scored_card)` function. But since that only takes in a single joker, and a single scored_card, I'm not sure if this would be able to handle things like jolly joker scoring on a pair, etc. I tried adding a `get_hand_type()` function to game.h, but quickly realized that won't work as the jokers will need some kind of contains_pair(), contains_three_of_a_kind(), etc, functions. Because you can have a flush that also contains a pair, and other complications.

And also these changes will have some conflicts with https://github.com/cellos51/balatro-gba/pull/63 if merged.

Also maybe off-topic for this kind of commit, but I removed the "// TODO: Make this random later" in joker_new, because `game_shop_create_items` already randomly chooses the id to use as an argument.