### PR TITLE
Adds walkie-talkie, fibonnaci, banner, mystic summit, blackboard

### DIFF
--- a/include/card.h
+++ b/include/card.h
@@ -35,6 +35,8 @@
 #define NUM_RANKS 13
 #define RANK_OFFSET 2 // Because the first rank is 2 and ranks start at 0
 
+#define IMPOSSIBLY_HIGH_CARD_VALUE 99
+
 // Card types
 typedef struct
 {

--- a/include/game.h
+++ b/include/game.h
@@ -82,6 +82,8 @@ int             get_played_top(void);
 JokerObject**   get_jokers(void);
 int             get_jokers_top(void);
 
+int get_deck_top(void);
+
 int get_num_discards_remaining(void);
 
 #endif // GAME_H

--- a/include/game.h
+++ b/include/game.h
@@ -83,7 +83,7 @@ JokerObject**   get_jokers(void);
 int             get_jokers_top(void);
 
 int get_deck_top(void);
-
 int get_num_discards_remaining(void);
+int get_money(void);
 
 #endif // GAME_H

--- a/include/graphic_utils.h
+++ b/include/graphic_utils.h
@@ -42,6 +42,7 @@
 
 // Tile size in pixels, both height and width as tiles are square
 #define TILE_SIZE 8
+#define EFFECT_TEXT_SEPARATION_AMOUNT 32; // If we need to show multiple effects at once
 
 typedef struct
 {

--- a/source/game.c
+++ b/source/game.c
@@ -164,6 +164,18 @@ int get_jokers_top(void) {
     return jokers_top;
 }
 
+int get_deck_top(void) {
+    return deck_top;
+}
+
+int get_num_discards_remaining(void) {
+    return discards;
+}
+
+int get_money(void) {
+    return money;
+}
+
 // Consts
 
 // Rects                                       left     top     right   bottom
@@ -238,43 +250,6 @@ static const Rect SHOP_REROLL_RECT          = {88,      96,    UNDEFINED, UNDEFI
 #define PITCH_STEP_DRAW_SFX         24
 #define PITCH_STEP_UNDISCARD_SFX    2*PITCH_STEP_DRAW_SFX    
 // Naming the stage where cards return from the discard pile to the deck "undiscard"
-
-// get-functions, for other files to view game state (mainly for jokers)
-CardObject **get_hand_array(void) {
-    return hand;
-}
-
-int get_hand_top(void) {
-    return hand_top;
-}
-
-CardObject **get_played_array(void) {
-    return played;
-}
-
-int get_played_top(void) {
-    return played_top;
-}
-
-JokerObject **get_jokers(void) {
-    return jokers;
-}
-
-int get_jokers_top(void) {
-    return jokers_top;
-}
-
-int get_deck_top(void) {
-    return deck_top;
-}
-
-int get_num_discards_remaining(void) {
-    return discards;
-}
-
-int get_money(void) {
-    return money;
-}
 
 // General functions
 void set_seed(int seed)

--- a/source/game.c
+++ b/source/game.c
@@ -272,6 +272,10 @@ int get_num_discards_remaining(void) {
     return discards;
 }
 
+int get_money(void) {
+    return money;
+}
+
 // General functions
 void set_seed(int seed)
 {

--- a/source/game.c
+++ b/source/game.c
@@ -264,6 +264,10 @@ int get_jokers_top(void) {
     return jokers_top;
 }
 
+int get_deck_top(void) {
+    return deck_top;
+}
+
 int get_num_discards_remaining(void) {
     return discards;
 }

--- a/source/joker.c
+++ b/source/joker.c
@@ -243,7 +243,7 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
             tte_set_special(0xD000); // Blue
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.chips);
             tte_write(score_buffer);
-            cursorPosX += 30;
+            cursorPosX += EFFECT_TEXT_SEPARATION_AMOUNT;
         }
         if (joker_effect.mult > 0)
         {
@@ -252,7 +252,7 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.mult);
             tte_write(score_buffer);
-            cursorPosX += 30;
+            cursorPosX += EFFECT_TEXT_SEPARATION_AMOUNT;
         }
         if (joker_effect.xmult > 0)
         {
@@ -261,7 +261,7 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "X%d", joker_effect.xmult);
             tte_write(score_buffer);
-            cursorPosX += 30;
+            cursorPosX += EFFECT_TEXT_SEPARATION_AMOUNT;
         }
         if (joker_effect.money > 0)
         {
@@ -270,7 +270,7 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
             tte_set_special(0xC000); // Yellow
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.money);
             tte_write(score_buffer);
-            cursorPosX += 30;
+            cursorPosX += EFFECT_TEXT_SEPARATION_AMOUNT;
         }
 
         joker_object->joker->processed = true; // Mark the joker as processed

--- a/source/joker.c
+++ b/source/joker.c
@@ -235,32 +235,43 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
         *money += joker_effect.money;
         // TODO: Retrigger
 
-        tte_set_pos(fx2int(joker_object->sprite_object->x) + 8, JOKER_SCORE_TEXT_Y); // Offset of 16 pixels to center the text on the card
-
-        char score_buffer[12];
-
+        int cursorPosX = fx2int(joker_object->sprite_object->x) + 8; // Offset of 16 pixels to center the text on the card
         if (joker_effect.chips > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xD000); // Blue
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.chips);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.mult > 0)
+        if (joker_effect.mult > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.mult);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.xmult > 0)
+        if (joker_effect.xmult > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "X%d", joker_effect.xmult);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.money > 0)
+        if (joker_effect.money > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xC000); // Yellow
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.money);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-
-        tte_write(score_buffer);
 
         joker_object->joker->processed = true; // Mark the joker as processed
         joker_object_shake(joker_object, SFX_CARD_SELECT); // TODO: Add a sound effect for scoring the joker

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -291,7 +291,163 @@ static JokerEffect blue_joker_effect(Joker *joker, Card *scored_card) {
     JokerEffect effect = {0};
     if (scored_card != NULL)
         return effect; // if card != null, we are not at the end-phase of scoring yet
+
     effect.chips = (get_deck_top() + 1) * 2;
+
+    return effect;
+}
+
+static JokerEffect raised_fist_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    // Find the lowest rank card in hand
+    // Aces are always considered high value, even in an ace-low straight
+    u8 lowest_value = 99;
+    CardObject** hand = get_hand_array();
+    int hand_top = get_hand_top();
+    for (int i = 0; i < hand_top; i++ )
+    {
+        u8 value = card_get_value(hand[i]->card);
+        if (lowest_value > value)
+            lowest_value = value;
+    }
+
+    if (lowest_value != 99)
+        effect.mult = lowest_value * 2;
+
+    return effect;
+}
+
+static JokerEffect reserved_parking_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    CardObject** hand = get_hand_array();
+    int hand_top = get_hand_top();
+    for (int i = 0; i < hand_top; i++ )
+    {
+        switch (hand[i]->card->rank) {
+            case KING: case QUEEN: case JACK:
+                if (random() % 2 == 0)
+                    effect.money += 1;
+            default:
+                break;
+        }
+    }
+
+    return effect;
+}
+
+static JokerEffect business_card_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            if (random() % 2 == 0)
+                effect.money = 1;
+        default:
+            break;
+    }
+
+    effect.chips = 1;
+
+    return effect;
+}
+
+static JokerEffect scholar_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (scored_card->rank == ACE) {
+        effect.chips = 20;
+        effect.mult = 4;
+    }
+
+    return effect;
+}
+
+static JokerEffect scary_face_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            effect.chips = 30;
+        default:
+            break;
+    }
+
+    return effect;
+}
+
+static JokerEffect abstract_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    // +1 xmult per occupied joker slot
+    int jokers_top = get_jokers_top();
+    effect.mult = (jokers_top + 1) * 3;
+
+    return effect;
+}
+
+static JokerEffect bull_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    effect.chips = get_money() * 2;
+
+    return effect;
+}
+
+static JokerEffect smiley_face_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            effect.mult = 5;
+        default:
+            break;
+    }
+
+    return effect;
+}
+
+static JokerEffect even_steven_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (card_get_value(scored_card) % 2 == 0) {
+        switch (scored_card->rank) {
+            case KING: case QUEEN: case JACK:
+                break;
+            default:
+                effect.mult = 4;
+        }
+    }
+
+    return effect;
+}
+
+static JokerEffect odd_todd_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (card_get_value(scored_card) % 2 == 1) // todo test ace
+        effect.chips = 31;
 
     return effect;
 }
@@ -321,6 +477,16 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 5, mystic_summit_joker_effect },
     { UNCOMMON_JOKER, 6, blackboard_joker_effect },
     { COMMON_JOKER, 5, blue_joker_effect },
+    { COMMON_JOKER, 5, raised_fist_joker_effect },
+    { COMMON_JOKER, 6, reserved_parking_joker_effect },
+    { COMMON_JOKER, 4, business_card_joker_effect },
+    { COMMON_JOKER, 4, scholar_joker_effect },
+    { COMMON_JOKER, 4, scary_face_joker_effect },
+    { COMMON_JOKER, 4, abstract_joker_effect },
+    { UNCOMMON_JOKER, 6, bull_joker_effect},
+    { COMMON_JOKER, 4, smiley_face_joker_effect },
+    { COMMON_JOKER, 4, even_steven_joker_effect },
+    { COMMON_JOKER, 4, odd_todd_joker_effect },
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -287,6 +287,15 @@ static JokerEffect blackboard_joker_effect(Joker *joker, Card *scored_card) {
     return effect;
 }
 
+static JokerEffect blue_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+    effect.chips = (get_deck_top() + 1) * 2;
+
+    return effect;
+}
+
 const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 2, default_joker_effect },  // DEFAULT_JOKER_ID = 0
     { COMMON_JOKER, 5, greedy_joker_effect },   // GREEDY_JOKER_ID = 1
@@ -311,6 +320,7 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 5, banner_joker_effect },
     { COMMON_JOKER, 5, mystic_summit_joker_effect },
     { UNCOMMON_JOKER, 6, blackboard_joker_effect },
+    { COMMON_JOKER, 5, blue_joker_effect },
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -304,7 +304,7 @@ static JokerEffect raised_fist_joker_effect(Joker *joker, Card *scored_card) {
 
     // Find the lowest rank card in hand
     // Aces are always considered high value, even in an ace-low straight
-    u8 lowest_value = 99;
+    u8 lowest_value = IMPOSSIBLY_HIGH_CARD_VALUE;
     CardObject** hand = get_hand_array();
     int hand_top = get_hand_top();
     for (int i = 0; i < hand_top; i++ )


### PR DESCRIPTION
This is based on https://github.com/cellos51/balatro-gba/pull/73/ , but we don't have artwork for these jokers yet so I wanted to make it a separate PR. This shouldn't be merged until after https://github.com/cellos51/balatro-gba/pull/73/ .

This adds a `get_num_discards_remaining()` function to game.c, and changes how joker's display their effect popup text (for walkie-talkie).

One bug with this commit is the walkie-talkie joker adds both chips and mult, but the popup effect that shows the bonus amount below the joker can only draw one benefit text at a time, so only the "+10" chips popup appears. Commit 534f2e4 in this PR solves this, but by printing both effects at once. The way the walkie-talkie works in the original game is that it appears to trigger twice, once for chip and once for mult.