### PR TITLE
Adds Shortcut and Four Fingers

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -88,5 +88,6 @@ int get_money(void);
 
 // joker specific functions
 bool is_shortcut_joker_active(void);
+int get_straight_and_flush_size(void);
 
 #endif // GAME_H

--- a/include/game.h
+++ b/include/game.h
@@ -86,4 +86,7 @@ int get_deck_top(void);
 int get_num_discards_remaining(void);
 int get_money(void);
 
+// joker specific functions
+bool is_shortcut_joker_active(void);
+
 #endif // GAME_H

--- a/include/game.h
+++ b/include/game.h
@@ -82,6 +82,8 @@ int             get_played_top(void);
 JokerObject**   get_jokers(void);
 int             get_jokers_top(void);
 
+int get_deck_top(void);
+
 int get_num_discards_remaining(void);
 
 #endif // GAME_H

--- a/include/game.h
+++ b/include/game.h
@@ -83,7 +83,7 @@ JokerObject**   get_jokers(void);
 int             get_jokers_top(void);
 
 int get_deck_top(void);
-
 int get_num_discards_remaining(void);
+int get_money(void);
 
 #endif // GAME_H

--- a/include/hand_analysis.h
+++ b/include/hand_analysis.h
@@ -13,4 +13,8 @@ bool hand_contains_full_house(u8 *ranks);
 bool hand_contains_straight(u8 *ranks);
 bool hand_contains_flush(u8 *suits);
 
+int find_flush_in_played_cards(CardObject** played, int top, int min_len, bool* out_selection);
+int find_straight_in_played_cards(CardObject** played, int top, bool shortcut_active, int min_len, bool* out_selection);
+void select_paired_cards_in_hand(CardObject** played, int top, bool* selection);
+
 #endif

--- a/include/joker.h
+++ b/include/joker.h
@@ -30,6 +30,7 @@
 #define DEFAULT_JOKER_ID 0
 #define GREEDY_JOKER_ID 1 // This is just an example to show the patern of making joker IDs
 #define JOKER_STENCIL_ID 16
+#define SHORTCUT_JOKER_ID 34
 
 typedef struct 
 {

--- a/include/joker.h
+++ b/include/joker.h
@@ -31,6 +31,7 @@
 #define GREEDY_JOKER_ID 1 // This is just an example to show the patern of making joker IDs
 #define JOKER_STENCIL_ID 16
 #define SHORTCUT_JOKER_ID 34
+#define FOUR_FINGERS_JOKER_ID 35
 
 typedef struct 
 {

--- a/source/game.c
+++ b/source/game.c
@@ -87,17 +87,34 @@ static int deck_top = -1;
 static Card *discard_pile[MAX_DECK_SIZE] = {NULL};
 static int discard_top = -1;
 
+// Joker Special Variables
+static bool SHORTCUT_JOKER_ACTIVE = false;
+bool is_shortcut_joker_active(void) {
+    return SHORTCUT_JOKER_ACTIVE;
+}
+
 // Joker stack
 static inline void joker_push(JokerObject *joker)
 {
     if (jokers_top >= MAX_JOKERS_HELD_SIZE - 1) return;
     jokers[++jokers_top] = joker;
+
+    if (joker->joker->id == SHORTCUT_JOKER_ID) {
+        SHORTCUT_JOKER_ACTIVE = true;
+    }
 }
 
 static inline JokerObject *joker_pop()
 {
     if (jokers_top < 0) return NULL;
-    return jokers[jokers_top--];
+
+    JokerObject *joker = jokers[jokers_top--];
+
+    if (joker->joker->id == SHORTCUT_JOKER_ID) {
+        SHORTCUT_JOKER_ACTIVE = false;
+    }
+
+    return joker;
 }
 
 // Played stack

--- a/source/game.c
+++ b/source/game.c
@@ -164,6 +164,18 @@ int get_jokers_top(void) {
     return jokers_top;
 }
 
+int get_deck_top(void) {
+    return deck_top;
+}
+
+int get_num_discards_remaining(void) {
+    return discards;
+}
+
+int get_money(void) {
+    return money;
+}
+
 // Consts
 
 // Rects                                       left     top     right   bottom
@@ -238,43 +250,6 @@ static const Rect SHOP_REROLL_RECT          = {88,      96,    UNDEFINED, UNDEFI
 #define PITCH_STEP_DRAW_SFX         24
 #define PITCH_STEP_UNDISCARD_SFX    2*PITCH_STEP_DRAW_SFX    
 // Naming the stage where cards return from the discard pile to the deck "undiscard"
-
-// get-functions, for other files to view game state (mainly for jokers)
-CardObject **get_hand_array(void) {
-    return hand;
-}
-
-int get_hand_top(void) {
-    return hand_top;
-}
-
-CardObject **get_played_array(void) {
-    return played;
-}
-
-int get_played_top(void) {
-    return played_top;
-}
-
-JokerObject **get_jokers(void) {
-    return jokers;
-}
-
-int get_jokers_top(void) {
-    return jokers_top;
-}
-
-int get_deck_top(void) {
-    return deck_top;
-}
-
-int get_num_discards_remaining(void) {
-    return discards;
-}
-
-int get_money(void) {
-    return money;
-}
 
 // General functions
 void set_seed(int seed)

--- a/source/game.c
+++ b/source/game.c
@@ -272,6 +272,10 @@ int get_num_discards_remaining(void) {
     return discards;
 }
 
+int get_money(void) {
+    return money;
+}
+
 // General functions
 void set_seed(int seed)
 {

--- a/source/game.c
+++ b/source/game.c
@@ -264,6 +264,10 @@ int get_jokers_top(void) {
     return jokers_top;
 }
 
+int get_deck_top(void) {
+    return deck_top;
+}
+
 int get_num_discards_remaining(void) {
     return discards;
 }

--- a/source/joker.c
+++ b/source/joker.c
@@ -148,7 +148,7 @@ void joker_destroy(Joker **joker)
 JokerEffect joker_get_score_effect(Joker *joker, Card *scored_card)
 {
     const JokerInfo *jinfo = get_joker_registry_entry(joker->id);
-    if (!jinfo) return (JokerEffect){0};
+    if (!jinfo || jinfo->effect == NULL) return (JokerEffect){0};
 
     return jinfo->effect(joker, scored_card);
 }

--- a/source/joker.c
+++ b/source/joker.c
@@ -235,32 +235,43 @@ bool joker_object_score(JokerObject *joker_object, Card* scored_card, int *chips
         *money += joker_effect.money;
         // TODO: Retrigger
 
-        tte_set_pos(fx2int(joker_object->sprite_object->x) + 8, JOKER_SCORE_TEXT_Y); // Offset of 16 pixels to center the text on the card
-
-        char score_buffer[12];
-
+        int cursorPosX = fx2int(joker_object->sprite_object->x) + 8; // Offset of 16 pixels to center the text on the card
         if (joker_effect.chips > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xD000); // Blue
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.chips);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.mult > 0)
+        if (joker_effect.mult > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.mult);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.xmult > 0)
+        if (joker_effect.xmult > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xE000); // Red
             snprintf(score_buffer, sizeof(score_buffer), "X%d", joker_effect.xmult);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-        else if (joker_effect.money > 0)
+        if (joker_effect.money > 0)
         {
+            char score_buffer[12];
+            tte_set_pos(cursorPosX, JOKER_SCORE_TEXT_Y);
             tte_set_special(0xC000); // Yellow
             snprintf(score_buffer, sizeof(score_buffer), "+%d", joker_effect.money);
+            tte_write(score_buffer);
+            cursorPosX += 30;
         }
-
-        tte_write(score_buffer);
 
         joker_object->joker->processed = true; // Mark the joker as processed
         joker_object_shake(joker_object, SFX_CARD_SELECT); // TODO: Add a sound effect for scoring the joker

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -487,7 +487,8 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 4, smiley_face_joker_effect },
     { COMMON_JOKER, 4, even_steven_joker_effect },
     { COMMON_JOKER, 4, odd_todd_joker_effect },
-    { UNCOMMON_JOKER, 7, NULL },  // Shortcut Joker, has no active effect
+    { UNCOMMON_JOKER, 7, NULL },  // Shortcut Joker, NULL because it has no active effect
+    { UNCOMMON_JOKER, 7, NULL },  // Four Fingers Joker, NULL because it has no active effect
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -487,6 +487,7 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 4, smiley_face_joker_effect },
     { COMMON_JOKER, 4, even_steven_joker_effect },
     { COMMON_JOKER, 4, odd_todd_joker_effect },
+    { UNCOMMON_JOKER, 7, NULL },  // Shortcut Joker, has no active effect
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -291,7 +291,163 @@ static JokerEffect blue_joker_effect(Joker *joker, Card *scored_card) {
     JokerEffect effect = {0};
     if (scored_card != NULL)
         return effect; // if card != null, we are not at the end-phase of scoring yet
+
     effect.chips = (get_deck_top() + 1) * 2;
+
+    return effect;
+}
+
+static JokerEffect raised_fist_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    // Find the lowest rank card in hand
+    // Aces are always considered high value, even in an ace-low straight
+    u8 lowest_value = 99;
+    CardObject** hand = get_hand_array();
+    int hand_top = get_hand_top();
+    for (int i = 0; i < hand_top; i++ )
+    {
+        u8 value = card_get_value(hand[i]->card);
+        if (lowest_value > value)
+            lowest_value = value;
+    }
+
+    if (lowest_value != 99)
+        effect.mult = lowest_value * 2;
+
+    return effect;
+}
+
+static JokerEffect reserved_parking_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    CardObject** hand = get_hand_array();
+    int hand_top = get_hand_top();
+    for (int i = 0; i < hand_top; i++ )
+    {
+        switch (hand[i]->card->rank) {
+            case KING: case QUEEN: case JACK:
+                if (random() % 2 == 0)
+                    effect.money += 1;
+            default:
+                break;
+        }
+    }
+
+    return effect;
+}
+
+static JokerEffect business_card_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            if (random() % 2 == 0)
+                effect.money = 1;
+        default:
+            break;
+    }
+
+    effect.chips = 1;
+
+    return effect;
+}
+
+static JokerEffect scholar_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (scored_card->rank == ACE) {
+        effect.chips = 20;
+        effect.mult = 4;
+    }
+
+    return effect;
+}
+
+static JokerEffect scary_face_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            effect.chips = 30;
+        default:
+            break;
+    }
+
+    return effect;
+}
+
+static JokerEffect abstract_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    // +1 xmult per occupied joker slot
+    int jokers_top = get_jokers_top();
+    effect.mult = (jokers_top + 1) * 3;
+
+    return effect;
+}
+
+static JokerEffect bull_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+
+    effect.chips = get_money() * 2;
+
+    return effect;
+}
+
+static JokerEffect smiley_face_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    switch (scored_card->rank) {
+        case KING: case QUEEN: case JACK:
+            effect.mult = 5;
+        default:
+            break;
+    }
+
+    return effect;
+}
+
+static JokerEffect even_steven_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (card_get_value(scored_card) % 2 == 0) {
+        switch (scored_card->rank) {
+            case KING: case QUEEN: case JACK:
+                break;
+            default:
+                effect.mult = 4;
+        }
+    }
+
+    return effect;
+}
+
+static JokerEffect odd_todd_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card == NULL)
+        return effect;
+
+    if (card_get_value(scored_card) % 2 == 1) // todo test ace
+        effect.chips = 31;
 
     return effect;
 }
@@ -321,6 +477,16 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 5, mystic_summit_joker_effect },
     { UNCOMMON_JOKER, 6, blackboard_joker_effect },
     { COMMON_JOKER, 5, blue_joker_effect },
+    { COMMON_JOKER, 5, raised_fist_joker_effect },
+    { COMMON_JOKER, 6, reserved_parking_joker_effect },
+    { COMMON_JOKER, 4, business_card_joker_effect },
+    { COMMON_JOKER, 4, scholar_joker_effect },
+    { COMMON_JOKER, 4, scary_face_joker_effect },
+    { COMMON_JOKER, 4, abstract_joker_effect },
+    { UNCOMMON_JOKER, 6, bull_joker_effect},
+    { COMMON_JOKER, 4, smiley_face_joker_effect },
+    { COMMON_JOKER, 4, even_steven_joker_effect },
+    { COMMON_JOKER, 4, odd_todd_joker_effect },
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -287,6 +287,15 @@ static JokerEffect blackboard_joker_effect(Joker *joker, Card *scored_card) {
     return effect;
 }
 
+static JokerEffect blue_joker_effect(Joker *joker, Card *scored_card) {
+    JokerEffect effect = {0};
+    if (scored_card != NULL)
+        return effect; // if card != null, we are not at the end-phase of scoring yet
+    effect.chips = (get_deck_top() + 1) * 2;
+
+    return effect;
+}
+
 const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 2, default_joker_effect },  // DEFAULT_JOKER_ID = 0
     { COMMON_JOKER, 5, greedy_joker_effect },   // GREEDY_JOKER_ID = 1
@@ -311,6 +320,7 @@ const JokerInfo joker_registry[] = {
     { COMMON_JOKER, 5, banner_joker_effect },
     { COMMON_JOKER, 5, mystic_summit_joker_effect },
     { UNCOMMON_JOKER, 6, blackboard_joker_effect },
+    { COMMON_JOKER, 5, blue_joker_effect },
 };
 
 static const size_t joker_registry_size = NUM_ELEM_IN_ARR(joker_registry);


### PR DESCRIPTION
This is based off my branch from #74 , so the PR includes all those commits as well. The new commits are d61a8a0d6bd5425abe9044e29cee638c3ba0972a (shortcut) and c6daf179dd52a42e205bdf6d1e2366af7102c2e3 (four fingers).

The code here is pretty ugly in some places. I used Google Gemini to help me come up with the new code for detecting straights and flushes, and selecting the correct cards for scoring. I tested pretty much every combination and fixed a few bugs, I think it's solid now. Some of this could probably be cleaner, but I'm not really sure how. Four Fingers has some pretty unique effects and the code would be much cleaner if Balatro didn't have those 🤣. For example

> Straights can score the same number multiple times using this card. For example, a hand with a 2, 3, 4, and two 5's will score all five cards as a straight. ([From the fandom wiki](https://balatrogame.fandom.com/wiki/Four_Fingers))

The shortcut commit adds `bool is_shortcut_joker_active()` and changes `hand_contains_straight` to have a much longer logic when shortcut is active in order to check for skips, this is one of the parts I had the AI write most of. It also adds the first joker with a NULL effect, so now `joker_get_score_effect` checks if the effect is null before trying to call it.

The Four Fingers commit is much uglier, because it also has to interact with Shortcut and the other straight jokers. It adds a `get_straight_and_flush_size()` and changes all straight/flush detection to be based on this, instead of length 5. The ugly part is handling scoring. Previously these were 5-card hands, and so the scoring logic was just to mark all 5 cards for scoring. Now that they can be 4 cards, we need to select which of the played cards are part of the valid straight/flush, and which one might be a trash card. It's also possible to score a rank twice in a straight, e.g. AA234 should score both Aces. This is another area I used AI to help write, I added `find_flush_in_played_cards` and `find_straight_in_played_cards`, which return a bool[MAX_HAND_SIZE] *(see note)*, where true = "score this card" and false = "do not score". And the scoring logic is changed to call these and select the correct cards. I kept the original `hand_contains_straight` and `hand_contains_flush` functions, which are used during the hand selection phase, because they're much faster, but we could simplify it by changing those to call the `find_*` versions of the function and return true if the arrays contain true values.

*note: Maybe this should be MAX_SELECTION_SIZE instead of MAX_HAND_SIZE? I realized this after testing everything. I think changing that would work without further changes, but I would have to do all that testing again, lol. But I think the only negative outcome is we use 6 extra bits of memory for the unused bool slots in the array. 3 for the flush array and 3 for the straight array.

There is also no artwork in these commits.