### PR TITLE
Optimized affine background HBLANK effect 

### DIFF
--- a/include/affine_background.h
+++ b/include/affine_background.h
@@ -7,7 +7,7 @@
 
 #define AFFINE_BG_PAL_LEN 5
 #define AFFINE_BG_PB (PAL_ROW_LEN * 15) // This isn't really a palette bank, just the starting index of the palette
-#define AFFINE_BG_IDX 2 // The index of BGCNT register etc.
+#define AFFINE_BG_IDX 2 // The index of the affine background BGCNT register etc.
 
 void affine_background_init();
 IWRAM_CODE void affine_background_hblank();

--- a/include/affine_background.h
+++ b/include/affine_background.h
@@ -7,10 +7,11 @@
 
 #define AFFINE_BG_PAL_LEN 5
 #define AFFINE_BG_PB (PAL_ROW_LEN * 15) // This isn't really a palette bank, just the starting index of the palette
+#define AFFINE_BG_IDX 2 // The index of BGCNT register etc.
 
 void affine_background_init();
-void affine_background_hblank();
-void affine_background_update();
+IWRAM_CODE void affine_background_hblank();
+IWRAM_CODE void affine_background_update();
 void affine_background_set_color(COLOR color);
 // Must be called with an array of size at least  AFFINE_BG_PAL_LEN
 void affine_background_load_palette(const u16 *src);

--- a/source/affine_background.c
+++ b/source/affine_background.c
@@ -3,11 +3,10 @@
 
 #include "graphic_utils.h"
 
-BG_AFFINE bgaff;
-AFF_SRC_EX asx = {32<<8, 64<<8, 120, 80, 0x0100, 0x0100, 0};
+BG_AFFINE bgaff_arr[SCREEN_HEIGHT + 1];
+
 static uint timer = 0;
 
-#define TOP_SCANLINE_OFFSET 228
 #define ANIMATION_SPEED_DIVISOR 16
 
 
@@ -17,41 +16,57 @@ void affine_background_init()
     GRIT_CPY(&se_mem[AFFINE_BG_SBB], affine_background_gfxMap);
     affine_background_load_palette(affine_background_gfxPal);
 
-    bgaff = bg_aff_default;
+    REG_BG_AFFINE[AFFINE_BG_IDX] = bg_aff_default;
 }
 
-void affine_background_hblank()
+// Pre-computes the affine matrices values for each scanline 
+// and stores in bgaff_arr. 
+// This is to be done in VBLANK so the HBLANK code 
+// can just fetch the values quickly.
+IWRAM_CODE void affine_background_prep_bgaff_arr()
+{
+    for (u16 vcount = 0; vcount < SCREEN_HEIGHT; vcount++)
+    {
+        AFF_SRC_EX asx = {32<<8, 64<<8, 120, 80, 0x0100, 0x0100, 0};
+        const s32 timer_s32 = timer << 8;
+        const s32 vcount_s32 = vcount << 8;
+        const s16 vcount_s16 = vcount;
+        const s32 vcount_sine = lu_sin(vcount_s32 + timer_s32 / ANIMATION_SPEED_DIVISOR); // dividing the timer by 16 to make the animation slower
+
+        asx.scr_x = (SCREEN_WIDTH / 2); // 128 on x and y is an offset used to center the rotation
+        asx.scr_y = vcount_s16 - (SCREEN_HEIGHT / 2); // scr_y must equal vcount otherwise the background will have no vertical difference
+        asx.tex_x = vcount_sine;
+        asx.tex_y = vcount_sine / 64;
+        asx.sx = vcount_sine / 32;
+        asx.sy = vcount_sine / 16;
+        asx.alpha = vcount_sine + (timer_s32 / ANIMATION_SPEED_DIVISOR);
+
+        bg_rotscale_ex(&bgaff_arr[vcount], &asx);
+    }
+
+    /* HBLANK occurs after the scanline so REG_VCOUNT represents the 
+     * the scanline that just passed, so when it's SCREEN_HEIGHT we will
+     * actually be updating the first line
+     */
+    bgaff_arr[SCREEN_HEIGHT] = bgaff_arr[0];
+}
+
+IWRAM_CODE void affine_background_hblank()
 {
     vu16 vcount = REG_VCOUNT;
 
-    if ((vcount > 160 && vcount < 225) || vcount > TOP_SCANLINE_OFFSET) // Exit the function if the scanline is outside the valid range
+    if ((vcount >= SCREEN_HEIGHT)) // Exit the function if the scanline is outside the screen
     {
         return;
     }
-    else if (vcount > TOP_SCANLINE_OFFSET - 3) // This fixes a visual issue where the top 3 pixels of the scanline are out of sync
-    {
-        vcount -= TOP_SCANLINE_OFFSET;
-    }
 
-    const s32 timer_s32 = timer << 8;
-    const s32 vcount_s32 = vcount << 8;
-    const s16 vcount_s16 = vcount;
-    const s32 vcount_sine = lu_sin(vcount_s32 + timer_s32 / ANIMATION_SPEED_DIVISOR); // dividing the timer by 16 to make the animation slower
-
-    asx.scr_x = (SCREEN_WIDTH / 2); // 128 on x and y is an offset used to center the rotation
-    asx.scr_y = vcount_s16 - (SCREEN_HEIGHT / 2); // scr_y must equal vcount otherwise the background will have no vertical difference
-    asx.tex_x = vcount_sine;
-    asx.tex_y = vcount_sine / 64;
-    asx.sx = vcount_sine / 32;
-    asx.sy = vcount_sine / 16;
-    asx.alpha = vcount_sine + (timer_s32 / ANIMATION_SPEED_DIVISOR);
-    
-    bg_rotscale_ex(&bgaff, &asx);
-    REG_BG_AFFINE[2] = bgaff;
+    // See comment in affine_background_prep_bgaff_arr()
+    REG_BG_AFFINE[AFFINE_BG_IDX] = bgaff_arr[vcount + 1];
 }
 
 void affine_background_update()
 {
+    affine_background_prep_bgaff_arr();
     timer++;
 }
 


### PR DESCRIPTION
I made some optimizations and there is an improvement but it's still not good enough, there is still text flickering and slowing and artifacts in the audio.

I moved the code to IWRAM to speed it up and moved the calculations to a VBLANK function that would pre-compute the values so the HBLANK function can just fetch them.

I also don't encounter the 3 first pixels issue anymore, not sure what caused it.

I tried to do some more fiddling for  optimization but to no avail. Maybe we can use some performance profiling tools to see which functions take the most time and try to optimize them.