### PR TITLE
Selection Grid System

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -3,23 +3,23 @@
 
 #include <stdbool.h>
 
-/* Defining an int list for simplicity
- * If another list is needed, a generic void*
- * list should be defined....
- */
-typedef struct IntList
+typedef struct List
 {
-    int* _array;
+    void** _array;
     int size;
     int allocated_size;
-} IntList;
+} List;
 
-IntList *int_list_new(int init_size);
-void int_list_destroy(IntList **list);
-bool int_list_append(IntList *list, int value);
-bool int_list_remove_by_idx(IntList *list, int index);
-int int_list_get(IntList *list, int index);
-int int_list_get_size(IntList *list);
-bool int_list_remove_by_value(IntList *list, int value);
+List *list_new(int init_size);
+void list_destroy(List **list);
+bool list_append(List *list, void *value);
+bool list_remove_by_idx(List *list, int index);
+void* list_get(List *list, int index);
+int list_get_size(List *list);
+bool list_remove_by_value(List *list, void *value);
+
+bool int_list_append(List *list, intptr_t value);
+intptr_t int_list_get(List *list, int index);
+bool int_list_remove_by_value(List *list, intptr_t value);
 
 #endif

--- a/include/selection_grid.h
+++ b/include/selection_grid.h
@@ -1,0 +1,41 @@
+#ifndef SELECTION_GRID_H
+#define SELECTION_GRID_H
+#include <tonc.h>
+
+typedef POINT Selection;
+
+struct SelectionGridRow;
+struct SelectionGrid;
+typedef struct SelectionGridRow SelectionGridRow;
+typedef struct SelectionGrid SelectionGrid;
+
+// Called whenever there is a change in the selection cursor
+// row_idx is the index of the row whose function is invoked - can be used to identify whether it is the previous or new selection row.
+typedef void (*RowOnSelectionChangedFunc)(SelectionGrid* selection_grid, int row_idx, const Selection* prev_selection, const Selection* new_selection);
+typedef int (*RowGetSizeFunc)();
+// Called for any non-directional key hit
+// The key will not be passed, the function will have to check key_hit() etc. for the key it wants to check
+typedef void (*RowOnKeyHitFunc)(SelectionGrid* selection_grid, Selection* selection);
+
+struct SelectionGridRow
+{
+    int row_idx;
+    RowGetSizeFunc get_size; 
+    RowOnSelectionChangedFunc on_selection_changed; 
+    RowOnKeyHitFunc on_key_hit;
+};
+
+struct SelectionGrid
+{
+    SelectionGridRow* rows;
+    const int num_rows;
+    Selection selection;
+ };
+
+
+void selection_grid_process_input(SelectionGrid* selection_grid);
+
+void selection_grid_move_selection_horz(SelectionGrid* selection_grid, int direction_tribool);
+void selection_grid_move_selection_vert(SelectionGrid* selection_grid, int direction_tribool);
+
+#endif

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -27,6 +27,8 @@ typedef struct
     FIXED rotation;
     FIXED vrotation;
     bool selected;
+    bool focused;
+    
 } SpriteObject;
 
 // Sprite methods
@@ -58,6 +60,7 @@ void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id);
 void sprite_object_set_selected(SpriteObject* sprite_object, bool selected);
 bool sprite_object_is_selected(SpriteObject* sprite_object);
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object);
-
+void sprite_object_set_focus(SpriteObject* sprite_object, bool focus);
+bool sprite_object_is_focused(SpriteObject* sprite_object);
 
 #endif // SPRITE_H

--- a/source/game.c
+++ b/source/game.c
@@ -239,6 +239,7 @@ static const Rect ROUND_END_NUM_HANDS_RECT  = {88,      116,    UNDEFINED, UNDEF
 static const Rect HAND_REWARD_RECT          = {168,     UNDEFINED, UNDEFINED, UNDEFINED };
 static const Rect CASHOUT_RECT              = {88,      72,     UNDEFINED, UNDEFINED };
 static const Rect SHOP_REROLL_RECT          = {88,      96,    UNDEFINED, UNDEFINED };
+#define ITEM_SHOP_Y 71 // TODO: Needs to be a rect?
 
 //TODO: Properly define and use
 #define MENU_POP_OUT_ANIM_FRAMES 20
@@ -1002,7 +1003,7 @@ void game_set_state(enum GameState new_game_state)
     game_state = new_game_state;
 }
 
-void jokers_avialable_to_shop_init()
+void jokers_available_to_shop_init()
 {
     int num_defined_jokers = get_joker_registry_size();
     jokers_available_to_shop = int_list_new(num_defined_jokers);
@@ -1015,7 +1016,7 @@ void jokers_avialable_to_shop_init()
 
 void game_init()
 {
-    jokers_avialable_to_shop_init();
+    jokers_available_to_shop_init();
 
     hands = max_hands;
     discards = max_discards;
@@ -1789,11 +1790,6 @@ static void held_jokers_update_loop()
         jokers[i]->sprite_object->tx = hand_x - int2fx(spacing_lut[jokers_top][i]);
         jokers[i]->sprite_object->ty = hand_y;
 
-        if (joker_object_is_selected(jokers[i]))
-        {
-            jokers[i]->sprite_object->ty -= int2fx(10);
-        }
-
         joker_object_update(jokers[i]);
     }
 }
@@ -2154,10 +2150,10 @@ static void game_shop_create_items(JokerObject *shop_jokers[])
         int_list_remove_by_idx(jokers_available_to_shop, joker_idx);
         
         shop_jokers[i] = joker_object_new(joker_new(joker_id));
-        shop_jokers[i]->sprite_object->x = int2fx(120 + i * 32);
+        shop_jokers[i]->sprite_object->x = int2fx(120 + i * CARD_SPRITE_SIZE);
         shop_jokers[i]->sprite_object->y = int2fx(160);
         shop_jokers[i]->sprite_object->tx = shop_jokers[i]->sprite_object->x;
-        shop_jokers[i]->sprite_object->ty = int2fx(71);
+        shop_jokers[i]->sprite_object->ty = int2fx(ITEM_SHOP_Y);
 
         int x = fx2int(shop_jokers[i]->sprite_object->tx) + TILE_SIZE - (get_digits_even(shop_jokers[i]->joker->value) - 1) * TILE_SIZE;
         int y = fx2int(shop_jokers[i]->sprite_object->ty) + CARD_SPRITE_SIZE + TILE_SIZE;
@@ -2228,6 +2224,8 @@ static void game_shop_reroll(JokerObject** shop_jokers, int *reroll_cost)
     (*reroll_cost)++;
     tte_printf("#{P:%d,%d; cx:0xF000}$%d", SHOP_REROLL_RECT.left, SHOP_REROLL_RECT.top, *reroll_cost);
 }
+
+
 
 // Shop menu input and selection
 static void game_shop_process_user_input(JokerObject** shop_jokers)
@@ -2322,8 +2320,6 @@ static void game_shop_process_user_input(JokerObject** shop_jokers)
         {
             if (i == selection_x - 1 && selection_y == 0)
             {
-                shop_jokers[i]->sprite_object->ty = int2fx(61);
-
                 if (key_hit(SELECT_CARD) && jokers_top < MAX_JOKERS_HELD_SIZE - 1 && money >= shop_jokers[i]->joker->value)
                 {
                     joker_push(shop_jokers[i]);
@@ -2341,10 +2337,6 @@ static void game_shop_process_user_input(JokerObject** shop_jokers)
 
                     shop_jokers[i] = NULL; // Remove the joker from the shop
                 }
-            }
-            else
-            {
-                shop_jokers[i]->sprite_object->ty = int2fx(71);
             }
         }
     }
@@ -2374,7 +2366,6 @@ static void game_shop_lights_anim_frame()
     memcpy16(&pal_bg_mem[22], &shifted_palette[2], 1);
     memcpy16(&pal_bg_mem[8], &shifted_palette[3], 1);
 }
-
 
 void game_shop()
 {
@@ -2472,8 +2463,6 @@ void game_shop()
             break;
     }
 }
-
-
 
 void game_blind_select()
 {

--- a/source/game.c
+++ b/source/game.c
@@ -174,7 +174,7 @@ int get_jokers_top(void) {
     return jokers_top;
 }
 
-IntList* jokers_available_to_shop; // List of joker IDs
+List* jokers_available_to_shop; // List of joker IDs
 
 // Consts
 
@@ -1009,8 +1009,8 @@ void game_set_state(enum GameState new_game_state)
 void jokers_available_to_shop_init()
 {
     int num_defined_jokers = get_joker_registry_size();
-    jokers_available_to_shop = int_list_new(num_defined_jokers);
-    for (int i = 0; i < num_defined_jokers; i++)
+    jokers_available_to_shop = list_new(num_defined_jokers);
+    for (intptr_t i = 0; i < num_defined_jokers; i++)
     {
         // Add all joker IDs sequentially
         int_list_append(jokers_available_to_shop, i);
@@ -2151,7 +2151,7 @@ static int reroll_cost = REROLL_BASE_COST;
 static void game_shop_create_items(JokerObject *shop_jokers[])
 {
     tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT);
-    if (int_list_get_size(jokers_available_to_shop) == 0)
+    if (list_get_size(jokers_available_to_shop) == 0)
     {
         // No jokers to create
         return;
@@ -2160,9 +2160,9 @@ static void game_shop_create_items(JokerObject *shop_jokers[])
     for (int i = 0; i < MAX_SHOP_JOKERS; i++)
     {
         // TODO: weight the random choice by joker rarity
-        int joker_idx = random() % int_list_get_size(jokers_available_to_shop);
-        int joker_id = int_list_get(jokers_available_to_shop, joker_idx);
-        int_list_remove_by_idx(jokers_available_to_shop, joker_idx);
+        int joker_idx = random() % list_get_size(jokers_available_to_shop);
+        intptr_t joker_id = int_list_get(jokers_available_to_shop, joker_idx);
+        list_remove_by_idx(jokers_available_to_shop, joker_idx);
         
         shop_jokers[i] = joker_object_new(joker_new(joker_id));
         shop_jokers[i]->sprite_object->x = int2fx(120 + i * CARD_SPRITE_SIZE);
@@ -2220,7 +2220,7 @@ static void game_shop_reroll(JokerObject** shop_jokers, int *reroll_cost)
     {
         if (shop_jokers[i] != NULL)
         {
-            int_list_append(jokers_available_to_shop, shop_jokers[i]->joker->id);
+            int_list_append(jokers_available_to_shop, (intptr_t)shop_jokers[i]->joker->id);
             joker_object_destroy(&shop_jokers[i]); // Destroy the joker object if it exists
         }
     }
@@ -2482,7 +2482,7 @@ void game_shop()
                 if (shop_jokers[i] != NULL)
                 {
                     // Make the joker available back to shop
-                    int_list_append(jokers_available_to_shop, shop_jokers[i]->joker->id);
+                    int_list_append(jokers_available_to_shop, (intptr_t)shop_jokers[i]->joker->id);
                 }
                 joker_object_destroy(&shop_jokers[i]); // Destroy the joker objects
             }

--- a/source/int_list.c
+++ b/source/int_list.c
@@ -3,10 +3,10 @@
 #include "list.h"
 #include "util.h"
 
-IntList *int_list_new(int init_size) {
-    IntList *list = (IntList *)malloc(sizeof(IntList));
+List *list_new(int init_size) {
+    List *list = (List *)malloc(sizeof(List));
     if (list == NULL) return NULL;
-    list->_array = (int *)malloc(sizeof(int) * init_size);
+    list->_array = (void **)malloc(sizeof(void*) * init_size);
     if (!list->_array) 
     {
         free(list);
@@ -17,7 +17,7 @@ IntList *int_list_new(int init_size) {
     return list;
 }
 
-void int_list_destroy(IntList **list) {
+void list_destroy(List **list) {
     if (list == NULL || *list == NULL)
         return; 
     {
@@ -28,22 +28,28 @@ void int_list_destroy(IntList **list) {
     *list = NULL;
 }
 
-bool int_list_append(IntList *list, int value) 
+bool int_list_append(List *list, intptr_t value) 
+{
+    return list_append(list, (void*)value);
+}
+
+bool list_append(List *list, void *value)
 {
     if (list->size >= list->allocated_size) 
     {
         int new_size = list->allocated_size * 2;
-        int *new_arr = (int *)realloc(list->_array, sizeof(int) * new_size);
+        void **new_arr = (void **)realloc(list->_array, sizeof(void*) * new_size);
         if (new_arr == NULL) 
             return false;
         list->_array = new_arr;
         list->allocated_size = new_size;
     }
+
     list->_array[list->size++] = value;
     return true;
 }
 
-bool int_list_remove_by_idx(IntList *list, int index) {
+bool list_remove_by_idx(List *list, int index) {
     if (index < 0 || index >= list->size) 
         return false;
     for (int i = index; i < list->size - 1; ++i) 
@@ -54,27 +60,37 @@ bool int_list_remove_by_idx(IntList *list, int index) {
     return true;
 }
 
-bool int_list_remove_by_value(IntList *list, int value)
+bool list_remove_by_value(List *list, void* value)
 {
     for (int i = 0; i < list->size; i++)
     {
         if (list->_array[i] == value)
         {
-            return int_list_remove_by_idx(list, i);
+            return list_remove_by_idx(list, i);
         }
     }
 
     return false;
 }
 
-int int_list_get(IntList *list, int index) 
+bool int_list_remove_by_value(List *list, intptr_t value)
+{
+    return list_remove_by_value(list, (void*)value);
+}
+
+void* list_get(List *list, int index)
 {
     if (index < 0 || index >= list->size) 
-        return 0;
+        return NULL;
     return list->_array[index];
 }
 
-int int_list_get_size(IntList *list)
+intptr_t int_list_get(List *list, int index) 
+{
+    return (intptr_t)list_get(list, index);
+}
+
+int list_get_size(List *list)
 {
     if (list == NULL)
     {

--- a/source/selection_grid.c
+++ b/source/selection_grid.c
@@ -1,0 +1,79 @@
+#include "selection_grid.h"
+
+
+static void selection_grid_process_directional_input(SelectionGrid *selection_grid)
+{
+    int horz_tri_input = bit_tribool(key_hit(KEY_ANY), KI_RIGHT, KI_LEFT);
+
+    if (horz_tri_input != 0)
+    {
+        selection_grid_move_selection_horz(selection_grid, horz_tri_input);
+        /* Avoid handling both vertical and horizontal input at the same time, 
+         * it creates all sorts of difficult edge cases.
+         */
+        return; 
+    }
+
+    int vert_tri_input = bit_tribool(key_hit(KEY_ANY), KI_DOWN, KI_UP);
+
+    
+    if (vert_tri_input != 0)
+    {
+        selection_grid_move_selection_vert(selection_grid, vert_tri_input);
+    }
+
+}
+
+void selection_grid_move_selection_horz(SelectionGrid* selection_grid, 
+                                        int direction_tribool)
+{
+    Selection new_selection = selection_grid->selection;
+    new_selection.x += direction_tribool;
+    if( selection_grid->selection.y >= 0 
+        && selection_grid->selection.y < selection_grid->num_rows 
+        && new_selection.x >= 0 
+        && new_selection.x < selection_grid->rows[new_selection.y].get_size())
+    {
+        selection_grid->rows[new_selection.y].on_selection_changed(selection_grid, new_selection.y, &selection_grid->selection, &new_selection);
+        selection_grid->selection = new_selection;
+    }
+}
+
+void selection_grid_move_selection_vert(SelectionGrid *selection_grid, int direction_tribool)
+{
+    Selection selection = selection_grid->selection;
+    Selection new_selection = selection;
+    new_selection.y += direction_tribool;
+
+    if (new_selection.y >= 0 
+        && new_selection.y < selection_grid->num_rows)
+    {
+        int new_row_size = selection_grid->rows[new_selection.y].get_size();
+        if (selection.x >= new_row_size)
+        {
+            // TODO: Maintain relative horizontal position
+            // Clip selection to row size
+            new_selection.x = new_row_size - 1;
+        }
+        selection_grid->rows[selection.y].on_selection_changed(selection_grid, selection.y, &selection, &new_selection);
+        selection_grid->rows[new_selection.y].on_selection_changed(selection_grid, new_selection.y, &selection, &new_selection);
+        selection_grid->selection = new_selection;
+    }
+}
+
+void selection_grid_process_input(SelectionGrid *selection_grid)
+{
+    if (selection_grid == NULL || selection_grid->rows == NULL)
+        return;
+
+    selection_grid_process_directional_input(selection_grid);
+
+    u32 non_directional_key = KEY_ANY & ~KEY_DIR;
+    if (key_hit(non_directional_key))
+    {
+        Selection* selection = &selection_grid->selection; // To make the next line shorter and more readable
+        selection_grid->rows[selection->y].on_key_hit(selection_grid, selection);
+    }
+}
+
+

--- a/source/selection_grid.c
+++ b/source/selection_grid.c
@@ -55,7 +55,10 @@ void selection_grid_move_selection_vert(SelectionGrid *selection_grid, int direc
             // Clip selection to row size
             new_selection.x = new_row_size - 1;
         }
-        selection_grid->rows[selection.y].on_selection_changed(selection_grid, selection.y, &selection, &new_selection);
+        if (selection.y >= 0 && selection.y < selection_grid->num_rows)
+        {
+            selection_grid->rows[selection.y].on_selection_changed(selection_grid, selection.y, &selection, &new_selection);
+        }
         selection_grid->rows[new_selection.y].on_selection_changed(selection_grid, new_selection.y, &selection, &new_selection);
         selection_grid->selection = new_selection;
     }

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -1,6 +1,7 @@
 #include "sprite.h"
 #include "util.h"
 #include "audio_utils.h"
+#include "soundbank.h"
 
 #include <tonc.h>
 #include <stdlib.h>
@@ -247,8 +248,10 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
     {
         return;
     }
-    
-    sprite_object->ty = sprite_object->ty + (focus ? -1 : 1) * SPRITE_FOCUS_RAISE_PX;
+    sprite_object->focused = focus;
+
+    play_sfx(SFX_CARD_FOCUS , MM_BASE_PITCH_RATE + rand() % 512);
+    sprite_object->ty = sprite_object->ty + int2fx((focus ? -1 : 1) * SPRITE_FOCUS_RAISE_PX);
 }
 
 bool sprite_object_is_focused(SpriteObject* sprite_object)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -8,6 +8,7 @@
 
 #define MAX_SPRITES 128
 #define MAX_AFFINES 32
+#define SPRITE_FOCUS_RAISE_PX 10
 
 OBJ_ATTR obj_buffer[MAX_SPRITES];
 OBJ_AFFINE *obj_aff_buffer = (OBJ_AFFINE*)obj_buffer;
@@ -238,4 +239,19 @@ Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)
     if (sprite_object == NULL)
         return NULL;
     return sprite_object->sprite;
+}
+
+void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
+{
+    if (sprite_object->focused == focus)
+    {
+        return;
+    }
+    
+    sprite_object->ty = sprite_object->ty + (focus ? -1 : 1) * SPRITE_FOCUS_RAISE_PX;
+}
+
+bool sprite_object_is_focused(SpriteObject* sprite_object)
+{
+    return sprite_object->focused;
 }


### PR DESCRIPTION
For the joker selling mechanic, I added a selection grid system that generalizes the selection input processing.
It's static vertically so the vertical size needs to be pre-defined but the horizontal size is dynamic.
It allows each row to define functions for its size, how to handle cursor selection changes, and how to handle user input within the row.
I refactored the shop code to use it and I'm planning to add held joker selection there. Theoretically it can also be used in the round if we ever want to add joker selling there too, but it still needs to better calculate the horizontal position when moving between rows.
Since this is a big refactor I thought maybe this should be merged now rather than wait until the joker selling mechanic is added.
The only visible changes currently are that the selection cursor can't be on jokers in the shop that were bought, and that the selection focus will have a sound effect in the shop too now.