### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/build_ci_workflow.yml
+++ b/.github/workflows/build_ci_workflow.yml
@@ -8,14 +8,43 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      clear_cache:
+        description: 'Clear docker cache before running'
+        type: boolean
+        default: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Get docker image cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache
+          key: docker-images-${{ hashFiles('docker-compose.yml') }}
+
+      - name: Clear docker cache (if requested)
+        if: github.event.inputs.clear_cache == 'true'
+        run: |
+          echo "Clearing Docker cache..."
+          rm -rf /tmp/docker-cache
+          echo "Docker cache cleared"
+
+      - name: Load or pull images
+        run: |
+          if [ -f /tmp/docker-cache/balatro.tar ]; then
+            echo "Loading Image"
+            docker load -i /tmp/docker-cache/balatro.tar
+          else
+            echo "Pulling Image"
+            docker compose pull balatro
+            mkdir -p /tmp/docker-cache
+            docker save $(docker compose config | grep image: | awk '{print $2}') -o /tmp/docker-cache/balatro.tar
+          fi
 
       - name: Export UID/GID for Compose
         run: |
@@ -24,7 +53,3 @@ jobs:
 
       - name: Build the project
         run: docker compose -f docker-compose.yml run --rm balatro sh -c "make -j$(nproc)"
-
-      - name: Compose down
-        if: always()
-        run: docker compose -f docker-compose.yml down -v || true

--- a/.github/workflows/build_ci_workflow.yml
+++ b/.github/workflows/build_ci_workflow.yml
@@ -2,11 +2,12 @@ name: Build CI
 
 on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -15,47 +16,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
-      - name: Set devkitPro environment variables
-        run: |
-          # Installing to home directory to avoid permission denied on caching
-          echo "DEVKITPRO=/home/runner/devkitpro" >> $GITHUB_ENV
-          echo "DEVKITARM=/home/runner/devkitpro/devkitARM" >> $GITHUB_ENV
-          export PATH=$DEVKITARM/bin:$DEVKITPRO/tools/bin:$PATH
-          
-        # Caching to avoid excessive request to the devkitpro server from a runner because they 
-        # eventually block and result in permission denied 403.
-        # If that happens it takes like 2 hours until you can make requests again
-      - name: Cache devkitPro toolchain
-        id: cache-devkitpro
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/devkitpro
-          # Using a manual key version suffix - v{num}, if changes are made that make the
-          # cache stale and require a refresh, just  bump the version number so there's
-          # a cache miss. The key needs to match in the "Save devkitPro to cache" stage
-          # so you need to bump the number there too...
-          key: devkitpro-${{ runner.os }}-v1
 
-      - name: Set up devkitARM (if not cached)
-        if: steps.cache-devkitpro.outputs.cache-hit != 'true'
+      - name: Export UID/GID for Compose
         run: |
-          sudo apt update
-          wget https://apt.devkitpro.org/install-devkitpro-pacman
-          chmod +x install-devkitpro-pacman
-          sudo ./install-devkitpro-pacman
-          mkdir -p "$DEVKITPRO"
-          sudo dkp-pacman -Sy --noconfirm gba-dev
-          # Copy from installed directory to cacheable directory
-          sudo cp -r /opt/devkitpro "/home/runner"
-          sudo chown -R $USER:$USER "/home/runner/devkitpro"
-      - name: Save devkitPro to cache
-        if: steps.cache-devkitpro.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /home/runner/devkitpro
-          key: devkitpro-${{ runner.os }}-v1
+          echo "UID=$(id -u)" >> "$GITHUB_ENV"
+          echo "GID=$(id -g)" >> "$GITHUB_ENV"
 
       - name: Build the project
-        run: |
-          make
+        run: docker compose -f docker-compose.yml run --rm balatro sh -c "make -j$(nproc)"
+
+      - name: Compose down
+        if: always()
+        run: docker compose -f docker-compose.yml down -v || true

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ This **tech-demo/proof of concept** is strictly limited in content to a minimal 
 (D-Pad: Navigation) 
 # **Build Instructions:**
 
+## **-Docker-**
+A docker compose file is provided to build this project. 
+
+1.) Install [docker desktop](https://docs.docker.com/compose/install/). 
+
+2.) Open a terminal to this projects directory:
+- On **linux** run `UID=$(id -u) GID=$(id -g) docker compose up`
+- On **windows** run `docker compose up`
+
+Docker will build the project and the ROM will be in the same location as step 7 describes below.
+
 ## **-Windows-**
 Video Tutorial: https://youtu.be/72Zzo1VDYzQ?si=UDmEdbST1Cx1zZV2
 ### With `Git` (not required)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  balatro:
+    image: devkitpro/devkitarm:latest
+    working_dir: /balatro
+    volumes:
+      - ./:/balatro
+    user: "${UID-1000}:${GID-1000}"
+    command: ["sh", "-c", "make -j$(nproc)"]


### PR DESCRIPTION
Add docker support via a docker compose file with included instructions.

I've struggled with devkitpro setups and I've found it easier to just use their [official container](https://hub.docker.com/r/devkitpro/devkitarm). This compose file is pretty straight forward. 

I unfortunately cannot test this on windows right now. In the past, similar setups worked fine for me on windows, but if someone has docker desktop installed on windows already, mind confirming for me if I can't sooner :) . 