### PR TITLE
Wrap around hand selection when going out of bounds horizontally

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -851,8 +851,21 @@ void card_draw()
 
 void hand_set_focus(int index)
 {
-    if (index < 0 || index > hand_top || hand_state != HAND_SELECT) return;
-    selection_x = index;
+    if (hand_state != HAND_SELECT) return;
+
+    // Wrap around to the other side of the hand when going out of bounds on either side
+    if (index < 0)
+    {
+        selection_x = hand_top;
+    }
+    else if (index > hand_top)
+    {
+        selection_x = 0;
+    }
+    else
+    {
+        selection_x = index;
+    }
 
     play_sfx(SFX_CARD_FOCUS, MM_BASE_PITCH_RATE + rand() % 512);
 }


### PR DESCRIPTION
Currently, it is not possible to e.g. move from the first card in hand to the last by pressing Left while the first card is focused. This is a simple fix to allow that.


https://github.com/user-attachments/assets/4ccab210-e266-4f01-9611-a160164eee02

