### PR TITLE
Add git hash baked into ROM for bug reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,16 @@ GRAPHICS	:= graphics
 #---------------------------------------------------------------------------------
 ARCH	:=	-mthumb -mthumb-interwork
 
+GIT_DIRTY := $(shell git diff-index --quiet HEAD -- || echo "-dirty")
+GIT_HASH := $(shell git rev-parse --short HEAD)
+GIT_C_FLAGS := -DGIT_HASH=\"$(GIT_HASH)\" -DGIT_DIRTY=\"$(GIT_DIRTY)\"
+
 CFLAGS	:= -g -O3 -Wall -Werror\
         -mcpu=arm7tdmi -mtune=arm7tdmi \
         -ffast-math -fomit-frame-pointer -funroll-loops \
         $(ARCH)
+
+CFLAGS  += $(GIT_C_FLAGS)
 
 CFLAGS	+=	$(INCLUDE)
 

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,7 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+__attribute__((used))
+const char gba_version[] = "GBA_VERSION:" GIT_HASH GIT_DIRTY;
+
+#endif // VERSION_H

--- a/source/game.c
+++ b/source/game.c
@@ -28,6 +28,7 @@
 #include "soundbank.h"
 
 #include "list.h"
+#include "version.h"
 
 static uint rng_seed = 0;
 


### PR DESCRIPTION
Bake in a git commit hash to help identify card versions for dev. Helpful for bug reports.

https://github.com/cellos51/balatro-gba/issues/141